### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# All files require review from this team
+* @thunderbird/addons


### PR DESCRIPTION
This should restrict review to members of the `Addons` team:
https://github.com/orgs/thunderbird/teams/addons

Edit: This is guarded by the "Require review from Code Owners" branch protection rule (which is not yet enabled)