### PR TITLE
Do not log empty placeholder

### DIFF
--- a/modules/tools.mjs
+++ b/modules/tools.mjs
@@ -61,8 +61,6 @@ export async function writePrettyJSONFile(filePath, json) {
  * @returns {boolean} true if the URL returns a successful response, false otherwise
  */
 export async function validateUrl(url, placeholder = '') {
-  const placeholderText = placeholder ? `${placeholder} ` : '';
-
   try {
     const response = await fetch(url, {
       method: 'GET',
@@ -72,8 +70,9 @@ export async function validateUrl(url, placeholder = '') {
     if (response.ok) {
       return true;
     } else {
+      const logEntries = [response.status, placeholder, url];
       console.log(
-        ` - problematic URL found: ${response.status} - ${placeholderText} - ${url}`
+        ` - problematic URL found: ${logEntries.filter(Boolean).join(" - ")}`
       );
       return false;
     }


### PR DESCRIPTION
I messed this up in a previous review, I did not want to bother you with a small change and pushed my "fix" alongside your PR. I missed the purpose of `placeholderText`.

This restores the concept of suppressing an empty `placeholder`.